### PR TITLE
Upstash Adapter

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -8,42 +8,38 @@ export type AggregationMode = 'SUM' | 'MIN' | 'MAX'
 export type OrderingMode = 'ASC' | 'DESC'
 export type Score = number | '-inf' | '+inf'
 
-export abstract class RedisMultiAdapter {
-  abstract set(key: string, value: RawValue): RedisMultiAdapter
-  abstract expire(key: string, ttl: number): RedisMultiAdapter
-  abstract sadd(key: string, values: RawValue[]): RedisMultiAdapter
-  abstract zadd(
-    key: string,
-    scores: Score[],
-    members: RawValue[]
-  ): RedisMultiAdapter
-  abstract exec(): Promise<void>
-  abstract del(keys: string[]): RedisMultiAdapter
-  abstract zrem(key: string, values: RawValue[]): RedisMultiAdapter
-  abstract zunionstore(
+export interface RedisMultiAdapter {
+  set(key: string, value: RawValue): RedisMultiAdapter
+  expire(key: string, ttl: number): RedisMultiAdapter
+  sadd(key: string, values: RawValue[]): RedisMultiAdapter
+  zadd(key: string, scores: Score[], members: RawValue[]): RedisMultiAdapter
+  exec(): Promise<void>
+  del(keys: string[]): RedisMultiAdapter
+  zrem(key: string, values: RawValue[]): RedisMultiAdapter
+  zunionstore(
     destination: string,
     keys: string[],
     aggregate?: AggregationMode
   ): RedisMultiAdapter
-  abstract zinterstore(
+  zinterstore(
     destination: string,
     keys: string[],
     aggregate?: AggregationMode
   ): RedisMultiAdapter
 }
 
-export abstract class RedisAdapter {
-  abstract multi(): RedisMultiAdapter
-  abstract quit(): Promise<void>
-  abstract ttl(key: string): Promise<number>
-  abstract smembers(key: string): Promise<string[]>
-  abstract zcount(key: string, min?: Score, max?: Score): Promise<number>
-  abstract zrange(
+export interface RedisAdapter {
+  multi(): RedisMultiAdapter
+  quit(): Promise<void>
+  ttl(key: string): Promise<number>
+  smembers(key: string): Promise<string[]>
+  zcount(key: string, min?: Score, max?: Score): Promise<number>
+  zrange(
     key: string,
     start: number,
     stop: number,
     order?: OrderingMode
   ): Promise<string[]>
-  abstract get(key: string): Promise<string | null>
-  abstract del(keys: string[]): Promise<number>
+  get(key: string): Promise<string | null>
+  del(keys: string[]): Promise<number>
 }

--- a/src/adapters/ioredis.ts
+++ b/src/adapters/ioredis.ts
@@ -10,12 +10,11 @@ import {
 } from './base'
 const DEFAULT_URL = process.env['REDIS_URL'] || 'redis://localhost:6379'
 
-export class IORedisMulti extends RedisMultiAdapter {
+export class IORedisMulti implements RedisMultiAdapter {
   multi: ChainableCommander
   errorHandler: (err: unknown) => void
 
   constructor(origRedis: Redis, errorHandler = defaultErrorHandler) {
-    super()
     this.multi = origRedis.multi()
     this.errorHandler = errorHandler
   }
@@ -90,12 +89,11 @@ export class IORedisMulti extends RedisMultiAdapter {
   }
 }
 
-export class IORedis extends RedisAdapter {
+export class IORedis implements RedisAdapter {
   origRedis: Redis
   errorHandler: (err: unknown) => void
 
   constructor(url = DEFAULT_URL, errorHandler = defaultErrorHandler) {
-    super()
     this.origRedis = new Redis(url, {
       enableAutoPipelining: true,
     })

--- a/src/adapters/upstash.ts
+++ b/src/adapters/upstash.ts
@@ -1,0 +1,197 @@
+import {
+  RedisAdapter,
+  RedisMultiAdapter,
+  AggregationMode,
+  OrderingMode,
+  Score,
+  RawValue,
+} from './base'
+
+export type UpstashRequest = {
+  path?: string[]
+  body?: unknown
+}
+
+type UpstashResponse<TResult = unknown> =
+  | {
+      result: TResult
+      error?: never
+    }
+  | {
+      result?: never
+      error: string
+    }
+
+/**
+ * UpstashRest is a small wrapper around fetch and only meant for internal use
+ */
+class UpstashRest {
+  private readonly url: string
+  private readonly token
+
+  constructor(opts: { url: string; token: string }) {
+    this.url = opts.url
+    this.token = opts.token
+  }
+
+  public async multi<TResult extends unknown[]>(
+    command: unknown
+  ): Promise<TResult> {
+    return await this.fetch({ path: ['multi-exec'], body: command })
+  }
+  public async do<TResult>(...command: unknown[]): Promise<TResult> {
+    return await this.fetch({ body: command })
+  }
+
+  private async fetch<TResult>(req: UpstashRequest): Promise<TResult> {
+    const res = await fetch([this.url, ...(req.path ?? [])].join('/'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.token}`,
+      },
+      body: JSON.stringify(req.body),
+    })
+    if (res.status >= 400) {
+      throw new Error(await res.text())
+    }
+    const response = (await res.json()) as UpstashResponse<TResult>
+
+    if (response.error) {
+      throw new Error(`Error from Upstash: ${response.error}`)
+    }
+    // not sure why typescript doesn't detect this as non-nullable tbh
+    // eslint-disable-next-line
+    return response.result!
+  }
+}
+
+export class UpstashMulti implements RedisMultiAdapter {
+  private readonly commands: unknown[][]
+  private readonly client: UpstashRest
+
+  constructor(client: UpstashRest) {
+    this.client = client
+    this.commands = []
+  }
+
+  set(key: string, value: RawValue) {
+    this.commands.push(['set', key, value])
+    return this
+  }
+
+  expire(key: string, ttl: number) {
+    this.commands.push(['expire', key, ttl])
+    return this
+  }
+
+  sadd(key: string, values: RawValue[]) {
+    this.commands.push(['sadd', key, ...values])
+    return this
+  }
+
+  zadd(key: string, scores: Score[], members: RawValue[]) {
+    const zipped = scores.flatMap((s, i) => [s, members[i]])
+    this.commands.push(['zadd', key, ...zipped])
+    return this
+  }
+
+  async exec() {
+    await this.client.multi(this.commands)
+    // TODO: error handling
+  }
+
+  del(keys: string[]) {
+    this.commands.push(['del', ...keys])
+    return this
+  }
+
+  zrem(key: string, values: RawValue[]) {
+    this.commands.push(['zrem', key, ...values])
+    return this
+  }
+
+  zunionstore(
+    destination: string,
+    keys: string[],
+    aggregate?: AggregationMode
+  ): RedisMultiAdapter {
+    const aggSettings = aggregate ? ['AGGREGATE', aggregate] : []
+    this.commands.push([
+      'zunionstore',
+      destination,
+      keys.length,
+      ...keys,
+      ...aggSettings,
+    ])
+    return this
+  }
+
+  zinterstore(
+    destination: string,
+    keys: string[],
+    aggregate?: AggregationMode
+  ): RedisMultiAdapter {
+    const aggSettings = aggregate ? ['AGGREGATE', aggregate] : []
+    this.commands.push([
+      'zinterstore',
+      destination,
+      keys.length,
+      ...keys,
+      ...aggSettings,
+    ])
+    return this
+  }
+}
+
+export class Upstash implements RedisAdapter {
+  private readonly client: UpstashRest
+  constructor(opts: { url: string; token: string }) {
+    this.client = new UpstashRest(opts)
+  }
+
+  multi() {
+    return new UpstashMulti(this.client)
+  }
+
+  async quit() {
+    // this is a noop for REST
+  }
+
+  async ttl(key: string) {
+    return this.client.do<number>('ttl', key)
+  }
+
+  async get(key: string) {
+    return this.client.do<string>('get', key)
+  }
+
+  async del(keys: string[]) {
+    return this.client.do<number>('del', ...keys)
+  }
+
+  async smembers(key: string): Promise<string[]> {
+    return this.client.do('smembers', key)
+  }
+
+  async zcount(
+    key: string,
+    min: Score = '-inf',
+    max: Score = '+inf'
+  ): Promise<number> {
+    return this.client.do<number>('zcount', key, min, max)
+  }
+
+  async zrange(
+    key: string,
+    start: number,
+    stop: number,
+    order?: OrderingMode
+  ): Promise<string[]> {
+    if (order === 'DESC') {
+      return this.client.do('zrange', key, start, stop, 'REV')
+    } else {
+      return this.client.do('zrange', key, start, stop)
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { Redbase } from './redbase'
 export { IORedis } from './adapters/ioredis'
+export { Upstash } from './adapters/upstash'


### PR DESCRIPTION
- refactor(adapters): switch from abstract classes to interfaces
- feat(adapters): add upstash-rest adapater


I've chosen to go without dependencies here, because the `@upstash/redis` client is not as low level as the existing interfaces require and aims to provide a better typescript dx compared to existing clients like ioredis.

Instead this simply uses `fetch` and provides a small wrapper to implement the existing interfaces without having to convert types back and forth.

Caveat: If you're on node<18, you need a fetch polyfill.

So far I tried it with one of the example in the readme. and it worked great but we need to update the tests as well in order to test against upstash instead of a local redis db.

```ts
import { Upstash, Redbase } from 'redbase'



interface User {
  id: number
  name: string
}
interface Post {
  content: string
  userId: number
}

const redis = new Upstash({ url, token })
const users = new Redbase<User>('myProject-user', { redis })
const posts = new Redbase<Post>('myProject-post', { redis })
```