### PR TITLE
test: handle multi-level nested tags

### DIFF
--- a/test/tag.spec.ts
+++ b/test/tag.spec.ts
@@ -40,10 +40,12 @@ describe('Tag', () => {
     expect(tag.parent?.name).toEqual('test')
   })
 
-  it('should be able to create a slash-prepended tag by path', () => {
-    const tag = Tag.fromPath('/test/child')
-    expect(tag.name).toEqual('/test/child')
-    expect(tag.parent?.name).toEqual('/test')
-    expect(tag.parent?.parent).toEqual(Tag.root())
+  it('should correctly handle multi-level nested tags', () => {
+    const multiLevelTag = Tag.fromPath('level1/level2/level3')
+
+    expect(multiLevelTag.name).toEqual('level1/level2/level3')
+    expect(multiLevelTag.parent?.name).toEqual('level1/level2')
+    expect(multiLevelTag.parent?.parent?.name).toEqual('level1')
+    expect(multiLevelTag.parent?.parent?.parent).toEqual(Tag.root())
   })
 })

--- a/test/tag.spec.ts
+++ b/test/tag.spec.ts
@@ -40,6 +40,13 @@ describe('Tag', () => {
     expect(tag.parent?.name).toEqual('test')
   })
 
+  it('should be able to create a slash-prepended tag by path', () => {
+    const tag = Tag.fromPath('/test/child')
+    expect(tag.name).toEqual('/test/child')
+    expect(tag.parent?.name).toEqual('/test')
+    expect(tag.parent?.parent).toEqual(Tag.root())
+  })
+
   it('should correctly handle multi-level nested tags', () => {
     const multiLevelTag = Tag.fromPath('level1/level2/level3')
 


### PR DESCRIPTION
### Description of change

This PR introduces a new test case to verify the correct handling of multi-level nested tags. The test ensures that our Tag class correctly parses and handles tags that are nested multiple levels deep.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` (N/A)
- [ ] There are new or updated unit tests validating the change (N/A)
- [ ] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

